### PR TITLE
Ring buffer

### DIFF
--- a/functional_reader_test.go
+++ b/functional_reader_test.go
@@ -229,9 +229,8 @@ func TestMain(m *testing.M) {
 }
 
 func newReaderBlockSize(u *url.URL, bs int) (*Reader, error) {
-	hpr := &Reader{Fetcher: &HTTPRanger{URL: u}, BlockSize: bs}
-	err := hpr.init()
-	return hpr, err
+	fetcher := HTTPRanger{URL: u}
+	return NewReader(&fetcher, bs)
 }
 
 func TestSequentialRead(t *testing.T) {
@@ -365,10 +364,7 @@ func TestZipFilePartialRead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	length, err := hpr.Length()
-	if err != nil {
-		t.Fatal(err)
-	}
+	length := hpr.Length
 
 	zr, err := zip.NewReader(hpr, length)
 	if err != nil {
@@ -456,14 +452,16 @@ func TestLateFailure(t *testing.T) {
 // Initializes on first call to function (here, Length)
 func TestLateInit(t *testing.T) {
 	url, _ := url.Parse(testServer.URL + "/blocks/bl1")
-	hpr := &Reader{Fetcher: &HTTPRanger{URL: url}}
-	length, err := hpr.Length()
+	fetcher:= HTTPRanger{URL: url}
+	hpr,err:= NewReader(&fetcher)
+	length:= hpr.Length
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Log("Late-Init Length:", length)
 
-	hpr2 := &Reader{Fetcher: &HTTPRanger{URL: url}}
+	fetcher2:= HTTPRanger{URL: url}
+	hpr2,err:= NewReader(&fetcher2)
 	bytes := make([]byte, 1024)
 	n, err := hpr2.ReadAt(bytes, 100)
 	if err != nil {
@@ -612,7 +610,7 @@ func ExampleReader() {
 	url, _ := url.Parse(testServer.URL + "/b.zip")
 
 	reader, _ := NewReader(&HTTPRanger{URL: url})
-	length, _ := reader.Length()
+	length := reader.Length
 	zipreader, _ := zip.NewReader(reader, length)
 
 	for i, v := range zipreader.File {

--- a/functional_reader_test.go
+++ b/functional_reader_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"sync"
 	"testing"
 	"time"
 )
@@ -277,7 +276,7 @@ func TestSeekRead(t *testing.T) {
 	}
 }
 
-func TestAsynchronousRead(t *testing.T) {
+func TestRead(t *testing.T) {
 	sums := []string{
 		"85fcb2d0dddc364935ca7d5117e4f86a",
 		"85ae5cab9fdc677cf2c700e31009aa39",
@@ -305,19 +304,14 @@ func TestAsynchronousRead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wg := sync.WaitGroup{}
 	for i := 1; i <= 7; i++ {
 		n := int64(i)
-		wg.Add(1)
-		go func() {
-			cases[n-1].RunTest(t, hpr)
-			wg.Done()
-		}()
+		cases[n-1].RunTest(t, hpr)
 	}
-	wg.Wait()
+
 }
 
-func TestOverlappingAsynchronousRead(t *testing.T) {
+func TestOverlappingRead(t *testing.T) {
 	sums := []string{
 		"4f701cc42d5f238d8b89ac6fe65b2fbc",
 		"a649c4dbcfb1958cdc0435ac360dc720",
@@ -345,16 +339,10 @@ func TestOverlappingAsynchronousRead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wg := sync.WaitGroup{}
 	for i := 1; i <= 7; i++ {
 		n := int64(i)
-		wg.Add(1)
-		go func() {
-			cases[n-1].RunTest(t, hpr)
-			wg.Done()
-		}()
+		cases[n-1].RunTest(t, hpr)
 	}
-	wg.Wait()
 }
 
 func TestZipFilePartialRead(t *testing.T) {

--- a/functional_reader_test.go
+++ b/functional_reader_test.go
@@ -619,8 +619,11 @@ func ExampleReader() {
 
 	data := make([]byte, 16)
 
-	rc, _ := zipreader.File[0].Open()
-	defer rc.Close()
+	rc, err := zipreader.File[0].Open()
+	if(err!=nil){
+		defer rc.Close()
+	}
+	
 
 	io.ReadFull(rc, data)
 

--- a/reader.go
+++ b/reader.go
@@ -3,158 +3,80 @@ package ranger
 import (
 	"errors"
 	"io"
-	"sync"
 )
 
-// DefaultBlockSize is the default size for the blocks that are downloaded from the server and cached.
-const DefaultBlockSize int = 128 * 1024
+var defaultBuffSize = 1024 * 512
 
-// Reader is an io.ReaderAt and io.ReadSeeker backed by a partial block store.
 type Reader struct {
 	// the range fetcher with which to download blocks
-	Fetcher RangeFetcher
+	fetcher RangeFetcher
 
-	// size of the blocks fetched from the source and cached; lower values translate to lower memory usage, but typically require more requests
-	BlockSize int
+	buff       []byte
+	readPoint  int64
+	writePoint int64
 
-	once sync.Once
-	len  int64 // protected by once
-
-	mutex  sync.RWMutex
-	off    int64
-	blocks map[int][]byte
+	Length   int64
+	buffSize int
 }
 
 // ReadAt reads len(p) bytes from the ranged-over source.
 // It returns the number of bytes read and the error, if any.
 // ReadAt always returns a non-nil error when n < len(b). At end of file, that error is io.EOF.
 func (r *Reader) ReadAt(p []byte, off int64) (int, error) {
-	err := r.init()
-	if err != nil {
-		return 0, err
-	}
-
-	l := len(p)
-
 	if off < 0 {
 		return 0, errors.New("read before beginning of file")
 	}
-
-	if off+int64(l) > r.len {
-		l = int(r.len - off)
-	}
-
-	if off >= r.len {
+	if off >= r.Length {
 		return 0, errors.New("read beyond end of file")
 	}
-
-	// Lock here so that we don't end up dispatching
-	// multiple requests for the same blocks.
-	r.mutex.Lock()
-
-	startBlock, nblocks := blockRange(off, l, r.BlockSize)
-	blockNumbers := make([]int, nblocks)
-	ranges := make([]ByteRange, nblocks)
-	nreq := 0
-	for i := 0; i < nblocks; i++ {
-		bn := startBlock + i
-		if _, ok := r.blocks[bn]; ok {
-			continue
-		}
-		blockNumbers[nreq] = bn
-		ranges[nreq] = ByteRange{
-			int64(bn * r.BlockSize),
-			int64(((bn + 1) * r.BlockSize) - 1),
-		}
-		if ranges[nreq].End > r.len {
-			ranges[nreq].End = r.len
-		}
-
-		nreq++
-	}
-
-	ranges = ranges[:nreq]
-
-	blox, err := r.Fetcher.FetchRanges(ranges)
-	if err != nil {
-		r.mutex.Unlock()
-		return 0, err
-	}
-	for i, v := range blox {
-		r.blocks[blockNumbers[i]] = v.Data
-	}
-
-	r.mutex.Unlock()
-
-	return r.copyRangeToBuffer(p[:l], off)
-}
-
-// invariant: after init(); p is appropriately sized
-func (r *Reader) copyRangeToBuffer(p []byte, off int64) (int, error) {
-	remaining := len(p)
-	block := int(off / int64(r.BlockSize))
-	startOffset := off % int64(r.BlockSize)
-	ncopied := 0
-
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
-
-	for remaining > 0 {
-		copylen := r.BlockSize
-		if copylen > remaining {
-			copylen = remaining
-		}
-
-		// if we need to copy more bytes than exist in this block
-		if startOffset+int64(copylen) > int64(r.BlockSize) {
-			copylen = int(int64(r.BlockSize) - startOffset)
-		}
-
-		if _, ok := r.blocks[block]; !ok {
-			return 0, errors.New("lies: we were told we had blocks to copy")
-		}
-		copy(p[ncopied:ncopied+copylen], r.blocks[block][startOffset:])
-
-		remaining -= copylen
-		ncopied += copylen
-
-		block++
-		startOffset = 0
-	}
-
-	var err error
-	if off+int64(len(p)) == r.len {
-		err = io.EOF
-	}
-
-	return ncopied, err
-}
-
-// Length returns the length of the ranged-over source.
-func (r *Reader) Length() (int64, error) {
-	err := r.init()
-	if err != nil {
-		return 0, err
-	}
-	return r.len, nil
+	r.readPoint = off
+	return r.Read(p)
 }
 
 // Read reads len(p) bytes from ranged-over source.
 // It returns the number of bytes read and the error, if any.
 // EOF is signaled by a zero count with err set to io.EOF.
 func (r *Reader) Read(p []byte) (int, error) {
-	err := r.init()
-	if err != nil {
-		return 0, err
-	}
-
-	if r.off == r.len {
+	// all the zone is [-length,0](0,buffSize](buffSize,length]
+	distance := r.writePoint - r.readPoint
+	if r.readPoint >= r.Length {
 		return 0, io.EOF
 	}
-
-	nread, err := r.ReadAt(p, r.off)
-	r.off += int64(nread)
-	return nread, err
+	// (buffSize,length] U [-length,0]
+	if distance <= 0 || distance > int64(r.buffSize) {
+		r.writePoint = r.readPoint
+		err := r.fillBuff()
+		if err != nil {
+			return 0, nil
+		}
+	}
+	// (0,buffSize]
+	readIndex := r.readPoint % int64(r.buffSize)
+	writeIndex := r.writePoint % int64(r.buffSize)
+	if len(p) <= int(distance) {
+		length := ringRead(p, r.buff, int(readIndex), int(writeIndex))
+		r.readPoint = r.readPoint + int64(length)
+		if r.readPoint >= r.Length {
+			return length, io.EOF
+		} else {
+			return length, nil
+		}
+	}
+	// len(p) > distance
+	total := 0
+	for total < len(p) {
+		length := ringRead(p[total:], r.buff, int(readIndex), int(writeIndex))
+		r.readPoint = r.readPoint + int64(length)
+		total = total + length
+		if r.readPoint >= r.Length {
+			return total, io.EOF
+		}
+		err := r.fillBuff()
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
 }
 
 // Seek sets the offset for the next Read to offset, interpreted
@@ -162,24 +84,17 @@ func (r *Reader) Read(p []byte) (int, error) {
 // to the current offset, and 2 means relative to the end. It returns the new offset
 // and an error, if any.
 func (r *Reader) Seek(off int64, whence int) (int64, error) {
-	err := r.init()
-	if err != nil {
-		return 0, err
-	}
-
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
 
 	switch whence {
 	case 0: // set
-		r.off = off
+		r.readPoint = off
 	case 1: // cur
-		off = r.off + off
+		off = r.readPoint + off
 	case 2: // end
-		off = r.len + off
+		off = r.readPoint + off
 	}
 
-	if off > r.len {
+	if off > r.Length {
 		return 0, errors.New("seek beyond end of file")
 	}
 
@@ -187,32 +102,95 @@ func (r *Reader) Seek(off int64, whence int) (int64, error) {
 		return 0, errors.New("seek before beginning of file")
 	}
 
-	r.off = off
-	return r.off, nil
+	r.readPoint = off
+	return r.readPoint, nil
 }
 
-func (r *Reader) init() (err error) {
-	r.once.Do(func() {
-		r.blocks = make(map[int][]byte)
-		if r.BlockSize == 0 {
-			r.BlockSize = DefaultBlockSize
-		}
-
-		r.len, err = r.Fetcher.ExpectedLength()
-	})
-	return
-}
-
-// NewReader returns a newly-initialized Reader,
-// which also initializes its provided RangeFetcher.
-// It returns the new reader and an error, if any.
-func NewReader(fetcher RangeFetcher) (*Reader, error) {
-	r := &Reader{
-		Fetcher: fetcher,
+func ringRead(p []byte, ringBuff []byte, readIndex int, writeIndex int) int {
+	if writeIndex > readIndex {
+		return copy(p, ringBuff[readIndex:writeIndex])
+	} else {
+		length := copy(p, ringBuff[readIndex:])
+		length = length + copy(p[length:], ringBuff[:writeIndex])
+		return length
 	}
-	err := r.init()
+}
+
+func ringWrite(p []byte, ringBuff []byte, readIndex int, writeIndex int) int {
+	if writeIndex >= readIndex {
+		length := copy(ringBuff[writeIndex:], p)
+		length = length + copy(ringBuff[:readIndex], p[length:])
+		return length
+	} else {
+		return copy(ringBuff[writeIndex:readIndex], p)
+	}
+}
+
+// fill the ring buff
+func (r *Reader) fillBuff() error {
+	distance := r.writePoint - r.readPoint
+	// distance (-∞,0) U (buffSize,+∞)
+	if distance > int64(r.buffSize) {
+		r.writePoint = r.readPoint
+		distance = 0
+	}
+	if r.writePoint >= r.Length {
+		//reach the end
+		return nil
+	}
+	// distance [buffSize,buffSize]
+	if distance == int64(r.buffSize) {
+		//no need to fill
+		return nil
+	}
+	// distance [0,buffSize)
+	fillSize := r.buffSize - int(distance)
+	httpRangeStart := r.writePoint
+	httpRangeEnd := r.writePoint + int64(fillSize) - 1
+	if httpRangeEnd > r.Length-1 {
+		httpRangeEnd = r.Length - 1
+	}
+	ranges := make([]ByteRange, 0, 1)
+	byteRange := ByteRange{
+		Start: httpRangeStart,
+		End:   httpRangeEnd,
+	}
+	ranges = append(ranges, byteRange)
+	blocks, err := r.fetcher.FetchRanges(ranges)
 	if err != nil {
-		return nil, err
+		return err
 	}
+	value := blocks[0]
+	writeIndex := r.writePoint % int64(r.buffSize)
+	readIndex := r.readPoint % int64(r.buffSize)
+	length := ringWrite(value.Data[:value.Length], r.buff, int(readIndex), int(writeIndex))
+	r.writePoint = r.writePoint + int64(length)
+	return nil
+}
+
+// NewRingBuffReader returns a newly-initialized Reader,
+// which also initializes its provided RangeFetcher.
+// The size specifies the ring buff size
+// It returns the new reader and an error, if any.
+func NewReader(fetcher RangeFetcher, size ...int) (*Reader, error) {
+	r := &Reader{
+		fetcher:  fetcher,
+		buffSize: defaultBuffSize,
+	}
+	if len(size) > 0 {
+		r.buffSize = size[0]
+	}
+	if r.buffSize <= 0 {
+		return r, errors.New("buff size must be greater than 0")
+	}
+	length, err := r.fetcher.ExpectedLength()
+	if err != nil {
+		return r, err
+	}
+	if length <= 0 {
+		return nil, errors.New("resource is empty")
+	}
+	r.Length = length
+	r.buff = make([]byte, r.buffSize)
 	return r, nil
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -51,7 +51,8 @@ func TestReaderWithBadRangers(t *testing.T) {
 	})
 
 	subtest(t, "FailsToInitializeLate", func(t *testing.T) {
-		r := &Reader{Fetcher: &fetcherFailsToInitialize{}}
+		fetcher := fetcherFailsToInitialize{}
+		r, _ := NewReader(&fetcher)
 		_, err := r.ReadAt(nil, 10)
 		if err == nil {
 			t.Fail()
@@ -61,7 +62,8 @@ func TestReaderWithBadRangers(t *testing.T) {
 	})
 
 	subtest(t, "FailsToInitializeLate", func(t *testing.T) {
-		r := &Reader{Fetcher: &fetcherFailsToInitialize{}}
+		fetcher := fetcherFailsToInitialize{}
+		r, _ := NewReader(&fetcher)
 		_, err := r.Read(nil)
 		if err == nil {
 			t.Fail()
@@ -71,8 +73,8 @@ func TestReaderWithBadRangers(t *testing.T) {
 	})
 
 	subtest(t, "FailsToInitializeLate", func(t *testing.T) {
-		r := &Reader{Fetcher: &fetcherFailsToInitialize{}}
-		_, err := r.Length()
+		fetcher := fetcherFailsToInitialize{}
+		_, err := NewReader(&fetcher)
 		if err == nil {
 			t.Fail()
 		} else {
@@ -81,7 +83,8 @@ func TestReaderWithBadRangers(t *testing.T) {
 	})
 
 	subtest(t, "FailsToInitializeLate", func(t *testing.T) {
-		r := &Reader{Fetcher: &fetcherFailsToInitialize{}}
+		fetcher := fetcherFailsToInitialize{}
+		r, _ := NewReader(&fetcher)
 		_, err := r.Seek(0, 0)
 		if err == nil {
 			t.Fail()


### PR DESCRIPTION
Replace the former Reader with Ring-Buff-Reader.
The former Reader buffers all the data in a map and occupies unlimited memory according to the http resource.
Remove the unnecessary synchronization in Reder and update the associated test cases.
All test cases pass.